### PR TITLE
remove unused arg

### DIFF
--- a/src/Records/Address/BuildingSubunit.php
+++ b/src/Records/Address/BuildingSubunit.php
@@ -60,7 +60,7 @@ class BuildingSubunit {
 		return [ $num, $suffix ];
 	}
 
-	public function getAllBuildingTypes($val) {
+	public function getAllBuildingTypes() {
 		return [
 			"" => "",
 			"ANT" => "Antenna",


### PR DESCRIPTION
> PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function validate(), 2 passed in /path/to/file.php on line X and exactly 3 expected

>> PHP 7.1 this will throw a PHP Fatal error, not just a warning:

hi @xrobau nice lib thnx, I am writing python port and your lib is proving invaluable. Small fix for 7.1 cheers~

