### PR TITLE
Remove unnecessary requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,6 @@
 		"classmap": [ "src/" ]
 	},
 	"require": {
-		"php": ">= 5.6",
-		"ramsey/uuid": "^3.7",
-		"xrobau/pest": "^1.0"
+		"php": ">= 5.6"
 	}
 }


### PR DESCRIPTION
Both Pest and UUID are not referenced in this code and cause the dependency bundle to be bigger than necessary. They should be removed.